### PR TITLE
services.md: idle-culler does not need admin

### DIFF
--- a/docs/source/reference/services.md
+++ b/docs/source/reference/services.md
@@ -87,7 +87,7 @@ the Service. For example, a 'cull idle' notebook server task configured as a
 Hub-Managed Service would include:
 
 - the Service name,
-- admin permissions, and
+- permissions to see when users are active, and to stop servers
 - the `command` to launch the Service which will cull idle servers after a
   timeout interval
 


### PR DESCRIPTION
Small error in our docs- the idle culler example does not use admin permissions